### PR TITLE
sync generated protobuf code

### DIFF
--- a/src/pomerium-console/google/protobuf/descriptor.ts
+++ b/src/pomerium-console/google/protobuf/descriptor.ts
@@ -96,6 +96,13 @@ export interface FileDescriptorProto {
      */
     weakDependency: number[];
     /**
+     * Names of files imported by this file purely for the purpose of providing
+     * option extensions. These are excluded from the dependency list above.
+     *
+     * @generated from protobuf field: repeated string option_dependency = 15;
+     */
+    optionDependency: string[];
+    /**
      * All top-level definitions in this file.
      *
      * @generated from protobuf field: repeated google.protobuf.DescriptorProto message_type = 4;
@@ -128,11 +135,25 @@ export interface FileDescriptorProto {
     sourceCodeInfo?: SourceCodeInfo;
     /**
      * The syntax of the proto file.
-     * The supported values are "proto2" and "proto3".
+     * The supported values are "proto2", "proto3", and "editions".
+     *
+     * If `edition` is present, this value must be "editions".
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
      *
      * @generated from protobuf field: optional string syntax = 12;
      */
     syntax?: string;
+    /**
+     * The edition of the proto file.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
+     *
+     * @generated from protobuf field: optional google.protobuf.Edition edition = 14;
+     */
+    edition?: Edition;
 }
 /**
  * Describes a message type.
@@ -183,6 +204,12 @@ export interface DescriptorProto {
      * @generated from protobuf field: repeated string reserved_name = 10;
      */
     reservedName: string[];
+    /**
+     * Support for `export` and `local` keywords on enums.
+     *
+     * @generated from protobuf field: optional google.protobuf.SymbolVisibility visibility = 11;
+     */
+    visibility?: SymbolVisibility;
 }
 /**
  * @generated from protobuf message google.protobuf.DescriptorProto.ExtensionRange
@@ -228,6 +255,86 @@ export interface ExtensionRangeOptions {
      * @generated from protobuf field: repeated google.protobuf.UninterpretedOption uninterpreted_option = 999;
      */
     uninterpretedOption: UninterpretedOption[];
+    /**
+     * For external users: DO NOT USE. We are in the process of open sourcing
+     * extension declaration and executing internal cleanups before it can be
+     * used externally.
+     *
+     * @generated from protobuf field: repeated google.protobuf.ExtensionRangeOptions.Declaration declaration = 2;
+     */
+    declaration: ExtensionRangeOptions_Declaration[];
+    /**
+     * Any features defined in the specific edition.
+     *
+     * @generated from protobuf field: optional google.protobuf.FeatureSet features = 50;
+     */
+    features?: FeatureSet;
+    /**
+     * The verification state of the range.
+     * TODO: flip the default to DECLARATION once all empty ranges
+     * are marked as UNVERIFIED.
+     *
+     * @generated from protobuf field: optional google.protobuf.ExtensionRangeOptions.VerificationState verification = 3;
+     */
+    verification?: ExtensionRangeOptions_VerificationState;
+}
+/**
+ * @generated from protobuf message google.protobuf.ExtensionRangeOptions.Declaration
+ */
+export interface ExtensionRangeOptions_Declaration {
+    /**
+     * The extension number declared within the extension range.
+     *
+     * @generated from protobuf field: optional int32 number = 1;
+     */
+    number?: number;
+    /**
+     * The fully-qualified name of the extension field. There must be a leading
+     * dot in front of the full name.
+     *
+     * @generated from protobuf field: optional string full_name = 2;
+     */
+    fullName?: string;
+    /**
+     * The fully-qualified type name of the extension field. Unlike
+     * Metadata.type, Declaration.type must have a leading dot for messages
+     * and enums.
+     *
+     * @generated from protobuf field: optional string type = 3;
+     */
+    type?: string;
+    /**
+     * If true, indicates that the number is reserved in the extension range,
+     * and any extension field with the number will fail to compile. Set this
+     * when a declared extension field is deleted.
+     *
+     * @generated from protobuf field: optional bool reserved = 5;
+     */
+    reserved?: boolean;
+    /**
+     * If true, indicates that the extension must be defined as repeated.
+     * Otherwise the extension must be defined as optional.
+     *
+     * @generated from protobuf field: optional bool repeated = 6;
+     */
+    repeated?: boolean;
+}
+/**
+ * The verification state of the extension range.
+ *
+ * @generated from protobuf enum google.protobuf.ExtensionRangeOptions.VerificationState
+ */
+export enum ExtensionRangeOptions_VerificationState {
+    /**
+     * All the extensions of the range must be declared.
+     *
+     * @generated from protobuf enum value: DECLARATION = 0;
+     */
+    DECLARATION = 0,
+    /**
+     * @generated from protobuf enum value: UNVERIFIED = 1;
+     */
+    UNVERIFIED = 1
 }
 /**
  * Describes a field within a message.
@@ -304,12 +411,12 @@ export interface FieldDescriptorProto {
      * If true, this is a proto3 "optional". When a proto3 field is optional, it
      * tracks presence regardless of field type.
      *
-     * When proto3_optional is true, this field must be belong to a oneof to
-     * signal to old proto3 clients that presence is tracked for this field. This
-     * oneof is known as a "synthetic" oneof, and this field must be its sole
-     * member (each proto3 optional field gets its own synthetic oneof). Synthetic
-     * oneofs exist in the descriptor only, and do not generate any API. Synthetic
-     * oneofs must be ordered after all "real" oneofs.
+     * When proto3_optional is true, this field must belong to a oneof to signal
+     * to old proto3 clients that presence is tracked for this field. This oneof
+     * is known as a "synthetic" oneof, and this field must be its sole member
+     * (each proto3 optional field gets its own synthetic oneof). Synthetic oneofs
+     * exist in the descriptor only, and do not generate any API. Synthetic oneofs
+     * must be ordered after all "real" oneofs.
      *
      * For message fields, proto3_optional doesn't create any semantic change,
      * since non-repeated message fields always track presence. However it still
@@ -382,9 +489,10 @@ export enum FieldDescriptorProto_Type {
     STRING = 9,
     /**
      * Tag-delimited aggregate.
-     * Group type is deprecated and not supported in proto3. However, Proto3
+     * Group type is deprecated and not supported after google.protobuf. However, Proto3
      * implementations should still be able to parse the group wire format and
-     * treat group fields as unknown fields.
+     * treat group fields as unknown fields.  In Editions, the group wire format
+     * can be enabled via the `message_encoding` feature.
      *
      * @generated from protobuf enum value: TYPE_GROUP = 10;
      */
@@ -445,13 +553,17 @@ export enum FieldDescriptorProto_Label {
      */
     OPTIONAL = 1,
     /**
-     * @generated from protobuf enum value: LABEL_REQUIRED = 2;
-     */
-    REQUIRED = 2,
-    /**
      * @generated from protobuf enum value: LABEL_REPEATED = 3;
      */
-    REPEATED = 3
+    REPEATED = 3,
+    /**
+     * The required label is only allowed in google.protobuf.  In proto3 and Editions
+     * it's explicitly prohibited.  In Editions, the `field_presence` feature
+     * can be used to get this behavior.
+     *
+     * @generated from protobuf enum value: LABEL_REQUIRED = 2;
+     */
+    REQUIRED = 2
 }
 /**
  * Describes a oneof.
@@ -501,6 +613,12 @@ export interface EnumDescriptorProto {
      * @generated from protobuf field: repeated string reserved_name = 5;
      */
     reservedName: string[];
+    /**
+     * Support for `export` and `local` keywords on enums.
+     *
+     * @generated from protobuf field: optional google.protobuf.SymbolVisibility visibility = 6;
+     */
+    visibility?: SymbolVisibility;
 }
 /**
  * Range of reserved numeric values. Reserved values may not be used by
@@ -672,12 +790,16 @@ export interface FileOptions {
      */
     javaGenerateEqualsAndHash?: boolean;
     /**
-     * If set true, then the Java2 code generator will generate code that
-     * throws an exception whenever an attempt is made to assign a non-UTF-8
-     * byte sequence to a string field.
-     * Message reflection will do the same.
-     * However, an extension field still accepts non-UTF-8 byte sequences.
-     * This option has no effect on when used with the lite runtime.
+     * A proto2 file can set this to true to opt in to UTF-8 checking for Java,
+     * which will throw an exception if invalid UTF-8 is parsed from the wire or
+     * assigned to a string field.
+     *
+     * TODO: clarify exactly what kinds of field types this option
+     * applies to, and update these docs accordingly.
+     *
+     * Proto3 files already perform these checks. Setting the option explicitly to
+     * false has no effect: it cannot be used to opt proto3 files out of UTF-8
+     * checks.
      *
      * @generated from protobuf field: optional bool java_string_check_utf8 = 27;
      */
@@ -719,10 +841,6 @@ export interface FileOptions {
      * @generated from protobuf field: optional bool py_generic_services = 18;
      */
     pyGenericServices?: boolean;
-    /**
-     * @generated from protobuf field: optional bool php_generic_services = 42;
-     */
-    phpGenericServices?: boolean;
     /**
      * Is this file deprecated?
      * Depending on the target platform, this can emit Deprecated annotations
@@ -792,6 +910,15 @@ export interface FileOptions {
      * @generated from protobuf field: optional string ruby_package = 45;
      */
     rubyPackage?: string;
+    /**
+     * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
+     *
+     * @generated from protobuf field: optional google.protobuf.FeatureSet features = 50;
+     */
+    features?: FeatureSet;
     /**
      * The parser stores options it doesn't recognize here.
      * See the documentation for the "Options" section above.
@@ -902,6 +1029,31 @@ export interface MessageOptions {
      */
     mapEntry?: boolean;
     /**
+     * Enable the legacy handling of JSON field name conflicts.  This lowercases
+     * and strips underscored from the fields before comparison in proto3 only.
+     * The new behavior takes `json_name` into account and applies to proto2 as
+     * well.
+     *
+     * This should only be used as a temporary measure against broken builds due
+     * to the change in behavior for JSON field name conflicts.
+     *
+     * TODO This is legacy behavior we plan to remove once downstream
+     * teams have had time to migrate.
+     *
+     * @deprecated
+     * @generated from protobuf field: optional bool deprecated_legacy_json_field_conflicts = 11 [deprecated = true];
+     */
+    deprecatedLegacyJsonFieldConflicts?: boolean;
+    /**
+     * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
+     *
+     * @generated from protobuf field: optional google.protobuf.FeatureSet features = 12;
+     */
+    features?: FeatureSet;
+    /**
      * The parser stores options it doesn't recognize here. See above.
      *
      * @generated from protobuf field: repeated google.protobuf.UninterpretedOption uninterpreted_option = 999;
@@ -913,10 +1065,13 @@ export interface MessageOptions {
  */
 export interface FieldOptions {
     /**
+     * NOTE: ctype is deprecated. Use `features.(pb.cpp).string_type` instead.
      * The ctype option instructs the C++ code generator to use a different
      * representation of the field than it normally would.  See the specific
-     * options below.  This option is not yet implemented in the open source
-     * release -- sorry, we'll try to include it in a future version!
+     * options below.  This option is only implemented to support use of
+     * [ctype=CORD] and [ctype=STRING] (the default) on non-repeated fields of
+     * type "bytes" in the open source release.
+     * TODO: make ctype actually deprecated.
      *
      * @generated from protobuf field: optional google.protobuf.FieldOptions.CType ctype = 1;
      */
@@ -926,7 +1081,9 @@ export interface FieldOptions {
      * a more efficient representation on the wire. Rather than repeatedly
      * writing the tag and type for each element, the entire array is encoded as
      * a single length-delimited blob. In proto3, only explicit setting it to
-     * false will avoid using packed encoding.
+     * false will avoid using packed encoding.  This option is prohibited in
+     * Editions, but the `repeated_field_encoding` feature can be used to control
+     * the behavior.
      *
      * @generated from protobuf field: optional bool packed = 2;
      */
@@ -965,23 +1122,11 @@ export interface FieldOptions {
      * call from multiple threads concurrently, while non-const methods continue
      * to require exclusive access.
      *
-     *
-     * Note that implementations may choose not to check required fields within
-     * a lazy sub-message.  That is, calling IsInitialized() on the outer message
-     * may return true even if the inner message has missing required fields.
-     * This is necessary because otherwise the inner message would have to be
-     * parsed in order to perform the check, defeating the purpose of lazy
-     * parsing.  An implementation which chooses not to check required fields
-     * must be consistent about it.  That is, for any particular sub-message, the
-     * implementation must either *always* check its required fields, or *never*
-     * check its required fields, regardless of whether or not the message has
-     * been parsed.
-     *
-     * As of 2021, lazy does no correctness checks on the byte stream during
-     * parsing.  This may lead to crashes if and when an invalid byte stream is
-     * finally parsed upon access.
-     *
-     * TODO(b/211906113):  Enable validation on lazy fields.
+     * Note that lazy message fields are still eagerly verified to check
+     * ill-formed wireformat or missing required fields. Calling IsInitialized()
+     * on the outer message would fail if the inner message has missing required
+     * fields. Failed verification would result in parsing failure (except when
+     * uninitialized messages are acceptable).
      *
      * @generated from protobuf field: optional bool lazy = 5;
      */
@@ -1010,11 +1155,93 @@ export interface FieldOptions {
      */
     weak?: boolean;
     /**
+     * Indicate that the field value should not be printed out when using debug
+     * formats, e.g. when the field contains sensitive credentials.
+     *
+     * @generated from protobuf field: optional bool debug_redact = 16;
+     */
+    debugRedact?: boolean;
+    /**
+     * @generated from protobuf field: optional google.protobuf.FieldOptions.OptionRetention retention = 17;
+     */
+    retention?: FieldOptions_OptionRetention;
+    /**
+     * @generated from protobuf field: repeated google.protobuf.FieldOptions.OptionTargetType targets = 19;
+     */
+    targets: FieldOptions_OptionTargetType[];
+    /**
+     * @generated from protobuf field: repeated google.protobuf.FieldOptions.EditionDefault edition_defaults = 20;
+     */
+    editionDefaults: FieldOptions_EditionDefault[];
+    /**
+     * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
+     *
+     * @generated from protobuf field: optional google.protobuf.FeatureSet features = 21;
+     */
+    features?: FeatureSet;
+    /**
+     * @generated from protobuf field: optional google.protobuf.FieldOptions.FeatureSupport feature_support = 22;
+     */
+    featureSupport?: FieldOptions_FeatureSupport;
+    /**
      * The parser stores options it doesn't recognize here. See above.
      *
      * @generated from protobuf field: repeated google.protobuf.UninterpretedOption uninterpreted_option = 999;
      */
     uninterpretedOption: UninterpretedOption[];
+}
+/**
+ * @generated from protobuf message google.protobuf.FieldOptions.EditionDefault
+ */
+export interface FieldOptions_EditionDefault {
+    /**
+     * @generated from protobuf field: optional google.protobuf.Edition edition = 3;
+     */
+    edition?: Edition;
+    /**
+     * @generated from protobuf field: optional string value = 2;
+     */
+    value?: string; // Textproto value.
+}
+/**
+ * Information about the support window of a feature.
+ *
+ * @generated from protobuf message google.protobuf.FieldOptions.FeatureSupport
+ */
+export interface FieldOptions_FeatureSupport {
+    /**
+     * The edition that this feature was first available in.  In editions
+     * earlier than this one, the default assigned to EDITION_LEGACY will be
+     * used, and proto files will not be able to override it.
+     *
+     * @generated from protobuf field: optional google.protobuf.Edition edition_introduced = 1;
+     */
+    editionIntroduced?: Edition;
+    /**
+     * The edition this feature becomes deprecated in.  Using this after this
+     * edition may trigger warnings.
+     *
+     * @generated from protobuf field: optional google.protobuf.Edition edition_deprecated = 2;
+     */
+    editionDeprecated?: Edition;
+    /**
+     * The deprecation warning text if this feature is used after the edition it
+     * was marked deprecated in.
+     *
+     * @generated from protobuf field: optional string deprecation_warning = 3;
+     */
+    deprecationWarning?: string;
+    /**
+     * The edition this feature is no longer available in.  In editions after
+     * this one, the last default assigned will be used, and proto files will
+     * not be able to override it.
+     *
+     * @generated from protobuf field: optional google.protobuf.Edition edition_removed = 4;
+     */
+    editionRemoved?: Edition;
 }
 /**
  * @generated from protobuf enum google.protobuf.FieldOptions.CType
@@ -1027,6 +1254,13 @@ export enum FieldOptions_CType {
      */
     STRING = 0,
     /**
+     * The option [ctype=CORD] may be applied to a non-repeated field of type
+     * "bytes". It indicates that in C++, the data should be stored in a Cord
+     * instead of a string.  For very large strings, this may reduce memory
+     * fragmentation. It may also allow better performance when parsing from a
+     * Cord, or when parsing with aliasing enabled, as the parsed Cord may then
+     * alias the original buffer.
+     *
      * @generated from protobuf enum value: CORD = 1;
      */
     CORD = 1,
@@ -1059,9 +1293,86 @@ export enum FieldOptions_JSType {
     JS_NUMBER = 2
 }
 /**
+ * If set to RETENTION_SOURCE, the option will be omitted from the binary.
+ *
+ * @generated from protobuf enum google.protobuf.FieldOptions.OptionRetention
+ */
+export enum FieldOptions_OptionRetention {
+    /**
+     * @generated from protobuf enum value: RETENTION_UNKNOWN = 0;
+     */
+    RETENTION_UNKNOWN = 0,
+    /**
+     * @generated from protobuf enum value: RETENTION_RUNTIME = 1;
+     */
+    RETENTION_RUNTIME = 1,
+    /**
+     * @generated from protobuf enum value: RETENTION_SOURCE = 2;
+     */
+    RETENTION_SOURCE = 2
+}
+/**
+ * This indicates the types of entities that the field may apply to when used
+ * as an option. If it is unset, then the field may be freely used as an
+ * option on any kind of entity.
+ *
+ * @generated from protobuf enum google.protobuf.FieldOptions.OptionTargetType
+ */
+export enum FieldOptions_OptionTargetType {
+    /**
+     * @generated from protobuf enum value: TARGET_TYPE_UNKNOWN = 0;
+     */
+    TARGET_TYPE_UNKNOWN = 0,
+    /**
+     * @generated from protobuf enum value: TARGET_TYPE_FILE = 1;
+     */
+    TARGET_TYPE_FILE = 1,
+    /**
+     * @generated from protobuf enum value: TARGET_TYPE_EXTENSION_RANGE = 2;
+     */
+    TARGET_TYPE_EXTENSION_RANGE = 2,
+    /**
+     * @generated from protobuf enum value: TARGET_TYPE_MESSAGE = 3;
+     */
+    TARGET_TYPE_MESSAGE = 3,
+    /**
+     * @generated from protobuf enum value: TARGET_TYPE_FIELD = 4;
+     */
+    TARGET_TYPE_FIELD = 4,
+    /**
+     * @generated from protobuf enum value: TARGET_TYPE_ONEOF = 5;
+     */
+    TARGET_TYPE_ONEOF = 5,
+    /**
+     * @generated from protobuf enum value: TARGET_TYPE_ENUM = 6;
+     */
+    TARGET_TYPE_ENUM = 6,
+    /**
+     * @generated from protobuf enum value: TARGET_TYPE_ENUM_ENTRY = 7;
+     */
+    TARGET_TYPE_ENUM_ENTRY = 7,
+    /**
+     * @generated from protobuf enum value: TARGET_TYPE_SERVICE = 8;
+     */
+    TARGET_TYPE_SERVICE = 8,
+    /**
+     * @generated from protobuf enum value: TARGET_TYPE_METHOD = 9;
+     */
+    TARGET_TYPE_METHOD = 9
+}
+/**
  * @generated from protobuf message google.protobuf.OneofOptions
  */
 export interface OneofOptions {
+    /**
+     * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
+     *
+     * @generated from protobuf field: optional google.protobuf.FeatureSet features = 1;
+     */
+    features?: FeatureSet;
     /**
      * The parser stores options it doesn't recognize here. See above.
      *
@@ -1090,6 +1401,27 @@ export interface EnumOptions {
      */
     deprecated?: boolean;
     /**
+     * Enable the legacy handling of JSON field name conflicts.  This lowercases
+     * and strips underscored from the fields before comparison in proto3 only.
+     * The new behavior takes `json_name` into account and applies to proto2 as
+     * well.
+     * TODO Remove this legacy behavior once downstream teams have
+     * had time to migrate.
+     *
+     * @deprecated
+     * @generated from protobuf field: optional bool deprecated_legacy_json_field_conflicts = 6 [deprecated = true];
+     */
+    deprecatedLegacyJsonFieldConflicts?: boolean;
+    /**
+     * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
+     *
+     * @generated from protobuf field: optional google.protobuf.FeatureSet features = 7;
+     */
+    features?: FeatureSet;
+    /**
      * The parser stores options it doesn't recognize here. See above.
      *
      * @generated from protobuf field: repeated google.protobuf.UninterpretedOption uninterpreted_option = 999;
@@ -1110,6 +1442,29 @@ export interface EnumValueOptions {
      */
     deprecated?: boolean;
     /**
+     * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
+     *
+     * @generated from protobuf field: optional google.protobuf.FeatureSet features = 2;
+     */
+    features?: FeatureSet;
+    /**
+     * Indicate that fields annotated with this enum value should not be printed
+     * out when using debug formats, e.g. when the field contains sensitive
+     * credentials.
+     *
+     * @generated from protobuf field: optional bool debug_redact = 3;
+     */
+    debugRedact?: boolean;
+    /**
+     * Information about the support window of a feature value.
+     *
+     * @generated from protobuf field: optional google.protobuf.FieldOptions.FeatureSupport feature_support = 4;
+     */
+    featureSupport?: FieldOptions_FeatureSupport;
+    /**
      * The parser stores options it doesn't recognize here. See above.
      *
      * @generated from protobuf field: repeated google.protobuf.UninterpretedOption uninterpreted_option = 999;
@@ -1120,6 +1475,15 @@ export interface EnumValueOptions {
  * @generated from protobuf message google.protobuf.ServiceOptions
  */
 export interface ServiceOptions {
+    /**
+     * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
+     *
+     * @generated from protobuf field: optional google.protobuf.FeatureSet features = 34;
+     */
+    features?: FeatureSet;
     // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
     //   framework.  We apologize for hoarding these numbers to ourselves, but
     //   we were already using them long before we decided to release Protocol
@@ -1163,6 +1527,15 @@ export interface MethodOptions {
      * @generated from protobuf field: optional google.protobuf.MethodOptions.IdempotencyLevel idempotency_level = 34;
      */
     idempotencyLevel?: MethodOptions_IdempotencyLevel;
+    /**
+     * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
+     *
+     * @generated from protobuf field: optional google.protobuf.FeatureSet features = 35;
+     */
+    features?: FeatureSet;
     /**
      * The parser stores options it doesn't recognize here. See above.
      *
@@ -1258,6 +1631,270 @@ export interface UninterpretedOption_NamePart {
     isExtension: boolean;
 }
 // ===================================================================
+// Features
+
+/**
+ * TODO Enums in C++ gencode (and potentially other languages) are
+ * not well scoped.  This means that each of the feature enums below can clash
+ * with each other.  The short names we've chosen maximize call-site
+ * readability, but leave us very open to this scenario.  A future feature will
+ * be designed and implemented to handle this, hopefully before we ever hit a
+ * conflict here.
+ *
+ * @generated from protobuf message google.protobuf.FeatureSet
+ */
+export interface FeatureSet {
+    /**
+     * @generated from protobuf field: optional google.protobuf.FeatureSet.FieldPresence field_presence = 1;
+     */
+    fieldPresence?: FeatureSet_FieldPresence;
+    /**
+     * @generated from protobuf field: optional google.protobuf.FeatureSet.EnumType enum_type = 2;
+     */
+    enumType?: FeatureSet_EnumType;
+    /**
+     * @generated from protobuf field: optional google.protobuf.FeatureSet.RepeatedFieldEncoding repeated_field_encoding = 3;
+     */
+    repeatedFieldEncoding?: FeatureSet_RepeatedFieldEncoding;
+    /**
+     * @generated from protobuf field: optional google.protobuf.FeatureSet.Utf8Validation utf8_validation = 4;
+     */
+    utf8Validation?: FeatureSet_Utf8Validation;
+    /**
+     * @generated from protobuf field: optional google.protobuf.FeatureSet.MessageEncoding message_encoding = 5;
+     */
+    messageEncoding?: FeatureSet_MessageEncoding;
+    /**
+     * @generated from protobuf field: optional google.protobuf.FeatureSet.JsonFormat json_format = 6;
+     */
+    jsonFormat?: FeatureSet_JsonFormat;
+    /**
+     * @generated from protobuf field: optional google.protobuf.FeatureSet.EnforceNamingStyle enforce_naming_style = 7;
+     */
+    enforceNamingStyle?: FeatureSet_EnforceNamingStyle;
+    /**
+     * @generated from protobuf field: optional google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility default_symbol_visibility = 8;
+     */
+    defaultSymbolVisibility?: FeatureSet_VisibilityFeature_DefaultSymbolVisibility;
+}
+/**
+ * @generated from protobuf message google.protobuf.FeatureSet.VisibilityFeature
+ */
+export interface FeatureSet_VisibilityFeature {
+}
+/**
+ * @generated from protobuf enum google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility
+ */
+export enum FeatureSet_VisibilityFeature_DefaultSymbolVisibility {
+    /**
+     * @generated from protobuf enum value: DEFAULT_SYMBOL_VISIBILITY_UNKNOWN = 0;
+     */
+    DEFAULT_SYMBOL_VISIBILITY_UNKNOWN = 0,
+    /**
+     * Default pre-EDITION_2024, all UNSET visibility are export.
+     *
+     * @generated from protobuf enum value: EXPORT_ALL = 1;
+     */
+    EXPORT_ALL = 1,
+    /**
+     * All top-level symbols default to export, nested default to local.
+     *
+     * @generated from protobuf enum value: EXPORT_TOP_LEVEL = 2;
+     */
+    EXPORT_TOP_LEVEL = 2,
+    /**
+     * All symbols default to local.
+     *
+     * @generated from protobuf enum value: LOCAL_ALL = 3;
+     */
+    LOCAL_ALL = 3,
+    /**
+     * All symbols local by default. Nested types cannot be exported.
+     * With special case caveat for message { enum {} reserved 1 to max; }
+     * This is the recommended setting for new protos.
+     *
+     * @generated from protobuf enum value: STRICT = 4;
+     */
+    STRICT = 4
+}
+/**
+ * @generated from protobuf enum google.protobuf.FeatureSet.FieldPresence
+ */
+export enum FeatureSet_FieldPresence {
+    /**
+     * @generated from protobuf enum value: FIELD_PRESENCE_UNKNOWN = 0;
+     */
+    FIELD_PRESENCE_UNKNOWN = 0,
+    /**
+     * @generated from protobuf enum value: EXPLICIT = 1;
+     */
+    EXPLICIT = 1,
+    /**
+     * @generated from protobuf enum value: IMPLICIT = 2;
+     */
+    IMPLICIT = 2,
+    /**
+     * @generated from protobuf enum value: LEGACY_REQUIRED = 3;
+     */
+    LEGACY_REQUIRED = 3
+}
+/**
+ * @generated from protobuf enum google.protobuf.FeatureSet.EnumType
+ */
+export enum FeatureSet_EnumType {
+    /**
+     * @generated from protobuf enum value: ENUM_TYPE_UNKNOWN = 0;
+     */
+    ENUM_TYPE_UNKNOWN = 0,
+    /**
+     * @generated from protobuf enum value: OPEN = 1;
+     */
+    OPEN = 1,
+    /**
+     * @generated from protobuf enum value: CLOSED = 2;
+     */
+    CLOSED = 2
+}
+/**
+ * @generated from protobuf enum google.protobuf.FeatureSet.RepeatedFieldEncoding
+ */
+export enum FeatureSet_RepeatedFieldEncoding {
+    /**
+     * @generated from protobuf enum value: REPEATED_FIELD_ENCODING_UNKNOWN = 0;
+     */
+    REPEATED_FIELD_ENCODING_UNKNOWN = 0,
+    /**
+     * @generated from protobuf enum value: PACKED = 1;
+     */
+    PACKED = 1,
+    /**
+     * @generated from protobuf enum value: EXPANDED = 2;
+     */
+    EXPANDED = 2
+}
+/**
+ * @generated from protobuf enum google.protobuf.FeatureSet.Utf8Validation
+ */
+export enum FeatureSet_Utf8Validation {
+    /**
+     * @generated from protobuf enum value: UTF8_VALIDATION_UNKNOWN = 0;
+     */
+    UTF8_VALIDATION_UNKNOWN = 0,
+    /**
+     * @generated from protobuf enum value: VERIFY = 2;
+     */
+    VERIFY = 2,
+    /**
+     * @generated from protobuf enum value: NONE = 3;
+     */
+    NONE = 3
+}
+/**
+ * @generated from protobuf enum google.protobuf.FeatureSet.MessageEncoding
+ */
+export enum FeatureSet_MessageEncoding {
+    /**
+     * @generated from protobuf enum value: MESSAGE_ENCODING_UNKNOWN = 0;
+     */
+    MESSAGE_ENCODING_UNKNOWN = 0,
+    /**
+     * @generated from protobuf enum value: LENGTH_PREFIXED = 1;
+     */
+    LENGTH_PREFIXED = 1,
+    /**
+     * @generated from protobuf enum value: DELIMITED = 2;
+     */
+    DELIMITED = 2
+}
+/**
+ * @generated from protobuf enum google.protobuf.FeatureSet.JsonFormat
+ */
+export enum FeatureSet_JsonFormat {
+    /**
+     * @generated from protobuf enum value: JSON_FORMAT_UNKNOWN = 0;
+     */
+    JSON_FORMAT_UNKNOWN = 0,
+    /**
+     * @generated from protobuf enum value: ALLOW = 1;
+     */
+    ALLOW = 1,
+    /**
+     * @generated from protobuf enum value: LEGACY_BEST_EFFORT = 2;
+     */
+    LEGACY_BEST_EFFORT = 2
+}
+/**
+ * @generated from protobuf enum google.protobuf.FeatureSet.EnforceNamingStyle
+ */
+export enum FeatureSet_EnforceNamingStyle {
+    /**
+     * @generated from protobuf enum value: ENFORCE_NAMING_STYLE_UNKNOWN = 0;
+     */
+    ENFORCE_NAMING_STYLE_UNKNOWN = 0,
+    /**
+     * @generated from protobuf enum value: STYLE2024 = 1;
+     */
+    STYLE2024 = 1,
+    /**
+     * @generated from protobuf enum value: STYLE_LEGACY = 2;
+     */
+    STYLE_LEGACY = 2
+}
+/**
+ * A compiled specification for the defaults of a set of features.  These
+ * messages are generated from FeatureSet extensions and can be used to seed
+ * feature resolution. The resolution with this object becomes a simple search
+ * for the closest matching edition, followed by proto merges.
+ *
+ * @generated from protobuf message google.protobuf.FeatureSetDefaults
+ */
+export interface FeatureSetDefaults {
+    /**
+     * @generated from protobuf field: repeated google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault defaults = 1;
+     */
+    defaults: FeatureSetDefaults_FeatureSetEditionDefault[];
+    /**
+     * The minimum supported edition (inclusive) when this was constructed.
+     * Editions before this will not have defaults.
+     *
+     * @generated from protobuf field: optional google.protobuf.Edition minimum_edition = 4;
+     */
+    minimumEdition?: Edition;
+    /**
+     * The maximum known edition (inclusive) when this was constructed. Editions
+     * after this will not have reliable defaults.
+     *
+     * @generated from protobuf field: optional google.protobuf.Edition maximum_edition = 5;
+     */
+    maximumEdition?: Edition;
+}
+/**
+ * A map from every known edition with a unique set of defaults to its
+ * defaults. Not all editions may be contained here.  For a given edition,
+ * the defaults at the closest matching edition ordered at or before it should
+ * be used.  This field must be in strict ascending order by edition.
+ *
+ * @generated from protobuf message google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault
+ */
+export interface FeatureSetDefaults_FeatureSetEditionDefault {
+    /**
+     * @generated from protobuf field: optional google.protobuf.Edition edition = 3;
+     */
+    edition?: Edition;
+    /**
+     * Defaults of features that can be overridden in this edition.
+     *
+     * @generated from protobuf field: optional google.protobuf.FeatureSet overridable_features = 4;
+     */
+    overridableFeatures?: FeatureSet;
+    /**
+     * Defaults of features that can't be overridden in this edition.
+     *
+     * @generated from protobuf field: optional google.protobuf.FeatureSet fixed_features = 5;
+     */
+    fixedFeatures?: FeatureSet;
+}
+// ===================================================================
 // Optional source code info
 
 /**
@@ -1325,7 +1962,7 @@ export interface SourceCodeInfo_Location {
      * location.
      *
      * Each element is a field number or an index.  They form a path from
-     * the root FileDescriptorProto to the place where the definition occurs.
+     * the root FileDescriptorProto to the place where the definition appears.
      * For example, this path:
      *   [ 4, 3, 2, 7, 1 ]
      * refers to:
@@ -1461,12 +2098,141 @@ export interface GeneratedCodeInfo_Annotation {
     begin?: number;
     /**
      * Identifies the ending offset in bytes in the generated code that
-     * relates to the identified offset. The end offset should be one past
+     * relates to the identified object. The end offset should be one past
      * the last relevant byte (so the length of the text = end - begin).
      *
      * @generated from protobuf field: optional int32 end = 4;
      */
     end?: number;
+    /**
+     * @generated from protobuf field: optional google.protobuf.GeneratedCodeInfo.Annotation.Semantic semantic = 5;
+     */
+    semantic?: GeneratedCodeInfo_Annotation_Semantic;
+}
+/**
+ * Represents the identified object's effect on the element in the original
+ * .proto file.
+ *
+ * @generated from protobuf enum google.protobuf.GeneratedCodeInfo.Annotation.Semantic
+ */
+export enum GeneratedCodeInfo_Annotation_Semantic {
+    /**
+     * There is no effect or the effect is indescribable.
+     *
+     * @generated from protobuf enum value: NONE = 0;
+     */
+    NONE = 0,
+    /**
+     * The element is set or otherwise mutated.
+     *
+     * @generated from protobuf enum value: SET = 1;
+     */
+    SET = 1,
+    /**
+     * An alias to the element is returned.
+     *
+     * @generated from protobuf enum value: ALIAS = 2;
+     */
+    ALIAS = 2
+}
+/**
+ * The full set of known editions.
+ *
+ * @generated from protobuf enum google.protobuf.Edition
+ */
+export enum Edition {
+    /**
+     * A placeholder for an unknown edition value.
+     *
+     * @generated from protobuf enum value: EDITION_UNKNOWN = 0;
+     */
+    EDITION_UNKNOWN = 0,
+    /**
+     * A placeholder edition for specifying default behaviors *before* a feature
+     * was first introduced.  This is effectively an "infinite past".
+     *
+     * @generated from protobuf enum value: EDITION_LEGACY = 900;
+     */
+    EDITION_LEGACY = 900,
+    /**
+     * Legacy syntax "editions".  These pre-date editions, but behave much like
+     * distinct editions.  These can't be used to specify the edition of proto
+     * files, but feature definitions must supply proto2/proto3 defaults for
+     * backwards compatibility.
+     *
+     * @generated from protobuf enum value: EDITION_PROTO2 = 998;
+     */
+    EDITION_PROTO2 = 998,
+    /**
+     * @generated from protobuf enum value: EDITION_PROTO3 = 999;
+     */
+    EDITION_PROTO3 = 999,
+    /**
+     * Editions that have been released.  The specific values are arbitrary and
+     * should not be depended on, but they will always be time-ordered for easy
+     * comparison.
+     *
+     * @generated from protobuf enum value: EDITION_2023 = 1000;
+     */
+    EDITION_2023 = 1000,
+    /**
+     * @generated from protobuf enum value: EDITION_2024 = 1001;
+     */
+    EDITION_2024 = 1001,
+    /**
+     * Placeholder editions for testing feature resolution.  These should not be
+     * used or relied on outside of tests.
+     *
+     * @generated from protobuf enum value: EDITION_1_TEST_ONLY = 1;
+     */
+    EDITION_1_TEST_ONLY = 1,
+    /**
+     * @generated from protobuf enum value: EDITION_2_TEST_ONLY = 2;
+     */
+    EDITION_2_TEST_ONLY = 2,
+    /**
+     * @generated from protobuf enum value: EDITION_99997_TEST_ONLY = 99997;
+     */
+    EDITION_99997_TEST_ONLY = 99997,
+    /**
+     * @generated from protobuf enum value: EDITION_99998_TEST_ONLY = 99998;
+     */
+    EDITION_99998_TEST_ONLY = 99998,
+    /**
+     * @generated from protobuf enum value: EDITION_99999_TEST_ONLY = 99999;
+     */
+    EDITION_99999_TEST_ONLY = 99999,
+    /**
+     * Placeholder for specifying unbounded edition support.  This should only
+     * ever be used by plugins that can expect to never require any changes to
+     * support a new edition.
+     *
+     * @generated from protobuf enum value: EDITION_MAX = 2147483647;
+     */
+    EDITION_MAX = 2147483647
+}
+/**
+ * Describes the 'visibility' of a symbol with respect to the proto import
+ * system. Symbols can only be imported when the visibility rules do not prevent
+ * it (ex: local symbols cannot be imported).  Visibility modifiers can only set
+ * on `message` and `enum` as they are the only types available to be referenced
+ * from other files.
+ *
+ * @generated from protobuf enum google.protobuf.SymbolVisibility
+ */
+export enum SymbolVisibility {
+    /**
+     * @generated from protobuf enum value: VISIBILITY_UNSET = 0;
+     */
+    VISIBILITY_UNSET = 0,
+    /**
+     * @generated from protobuf enum value: VISIBILITY_LOCAL = 1;
+     */
+    VISIBILITY_LOCAL = 1,
+    /**
+     * @generated from protobuf enum value: VISIBILITY_EXPORT = 2;
+     */
+    VISIBILITY_EXPORT = 2
 }
 // @generated message type with reflection information, may provide speed optimized methods
 class FileDescriptorSet$Type extends MessageType<FileDescriptorSet> {
@@ -1524,13 +2290,15 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
             { no: 3, name: "dependency", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 10, name: "public_dependency", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 5 /*ScalarType.INT32*/ },
             { no: 11, name: "weak_dependency", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 5 /*ScalarType.INT32*/ },
+            { no: 15, name: "option_dependency", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "message_type", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => DescriptorProto },
             { no: 5, name: "enum_type", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => EnumDescriptorProto },
             { no: 6, name: "service", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ServiceDescriptorProto },
             { no: 7, name: "extension", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => FieldDescriptorProto },
             { no: 8, name: "options", kind: "message", T: () => FileOptions },
             { no: 9, name: "source_code_info", kind: "message", T: () => SourceCodeInfo },
-            { no: 12, name: "syntax", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
+            { no: 12, name: "syntax", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 14, name: "edition", kind: "enum", opt: true, T: () => ["google.protobuf.Edition", Edition] }
         ]);
     }
     create(value?: PartialMessage<FileDescriptorProto>): FileDescriptorProto {
@@ -1538,6 +2306,7 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         message.dependency = [];
         message.publicDependency = [];
         message.weakDependency = [];
+        message.optionDependency = [];
         message.messageType = [];
         message.enumType = [];
         message.service = [];
@@ -1574,6 +2343,9 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
                     else
                         message.weakDependency.push(reader.int32());
                     break;
+                case /* repeated string option_dependency */ 15:
+                    message.optionDependency.push(reader.string());
+                    break;
                 case /* repeated google.protobuf.DescriptorProto message_type */ 4:
                     message.messageType.push(DescriptorProto.internalBinaryRead(reader, reader.uint32(), options));
                     break;
@@ -1594,6 +2366,9 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
                     break;
                 case /* optional string syntax */ 12:
                     message.syntax = reader.string();
+                    break;
+                case /* optional google.protobuf.Edition edition */ 14:
+                    message.edition = reader.int32();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1622,6 +2397,9 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         /* repeated int32 weak_dependency = 11; */
         for (let i = 0; i < message.weakDependency.length; i++)
             writer.tag(11, WireType.Varint).int32(message.weakDependency[i]);
+        /* repeated string option_dependency = 15; */
+        for (let i = 0; i < message.optionDependency.length; i++)
+            writer.tag(15, WireType.LengthDelimited).string(message.optionDependency[i]);
         /* repeated google.protobuf.DescriptorProto message_type = 4; */
         for (let i = 0; i < message.messageType.length; i++)
             DescriptorProto.internalBinaryWrite(message.messageType[i], writer.tag(4, WireType.LengthDelimited).fork(), options).join();
@@ -1643,6 +2421,9 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         /* optional string syntax = 12; */
         if (message.syntax !== undefined)
             writer.tag(12, WireType.LengthDelimited).string(message.syntax);
+        /* optional google.protobuf.Edition edition = 14; */
+        if (message.edition !== undefined)
+            writer.tag(14, WireType.Varint).int32(message.edition);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1666,7 +2447,8 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
             { no: 8, name: "oneof_decl", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => OneofDescriptorProto },
             { no: 7, name: "options", kind: "message", T: () => MessageOptions },
             { no: 9, name: "reserved_range", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => DescriptorProto_ReservedRange },
-            { no: 10, name: "reserved_name", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
+            { no: 10, name: "reserved_name", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
+            { no: 11, name: "visibility", kind: "enum", opt: true, T: () => ["google.protobuf.SymbolVisibility", SymbolVisibility] }
         ]);
     }
     create(value?: PartialMessage<DescriptorProto>): DescriptorProto {
@@ -1718,6 +2500,9 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
                 case /* repeated string reserved_name */ 10:
                     message.reservedName.push(reader.string());
                     break;
+                case /* optional google.protobuf.SymbolVisibility visibility */ 11:
+                    message.visibility = reader.int32();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -1760,6 +2545,9 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
         /* repeated string reserved_name = 10; */
         for (let i = 0; i < message.reservedName.length; i++)
             writer.tag(10, WireType.LengthDelimited).string(message.reservedName[i]);
+        /* optional google.protobuf.SymbolVisibility visibility = 11; */
+        if (message.visibility !== undefined)
+            writer.tag(11, WireType.Varint).int32(message.visibility);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1887,12 +2675,16 @@ export const DescriptorProto_ReservedRange = new DescriptorProto_ReservedRange$T
 class ExtensionRangeOptions$Type extends MessageType<ExtensionRangeOptions> {
     constructor() {
         super("google.protobuf.ExtensionRangeOptions", [
-            { no: 999, name: "uninterpreted_option", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => UninterpretedOption }
+            { no: 999, name: "uninterpreted_option", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => UninterpretedOption },
+            { no: 2, name: "declaration", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ExtensionRangeOptions_Declaration },
+            { no: 50, name: "features", kind: "message", T: () => FeatureSet },
+            { no: 3, name: "verification", kind: "enum", opt: true, T: () => ["google.protobuf.ExtensionRangeOptions.VerificationState", ExtensionRangeOptions_VerificationState] }
         ]);
     }
     create(value?: PartialMessage<ExtensionRangeOptions>): ExtensionRangeOptions {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.uninterpretedOption = [];
+        message.declaration = [];
         if (value !== undefined)
             reflectionMergePartial<ExtensionRangeOptions>(this, message, value);
         return message;
@@ -1904,6 +2696,15 @@ class ExtensionRangeOptions$Type extends MessageType<ExtensionRangeOptions> {
             switch (fieldNo) {
                 case /* repeated google.protobuf.UninterpretedOption uninterpreted_option */ 999:
                     message.uninterpretedOption.push(UninterpretedOption.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* repeated google.protobuf.ExtensionRangeOptions.Declaration declaration */ 2:
+                    message.declaration.push(ExtensionRangeOptions_Declaration.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* optional google.protobuf.FeatureSet features */ 50:
+                    message.features = FeatureSet.internalBinaryRead(reader, reader.uint32(), options, message.features);
+                    break;
+                case /* optional google.protobuf.ExtensionRangeOptions.VerificationState verification */ 3:
+                    message.verification = reader.int32();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1920,6 +2721,15 @@ class ExtensionRangeOptions$Type extends MessageType<ExtensionRangeOptions> {
         /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
         for (let i = 0; i < message.uninterpretedOption.length; i++)
             UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.ExtensionRangeOptions.Declaration declaration = 2; */
+        for (let i = 0; i < message.declaration.length; i++)
+            ExtensionRangeOptions_Declaration.internalBinaryWrite(message.declaration[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* optional google.protobuf.FeatureSet features = 50; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(50, WireType.LengthDelimited).fork(), options).join();
+        /* optional google.protobuf.ExtensionRangeOptions.VerificationState verification = 3; */
+        if (message.verification !== undefined)
+            writer.tag(3, WireType.Varint).int32(message.verification);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1930,6 +2740,80 @@ class ExtensionRangeOptions$Type extends MessageType<ExtensionRangeOptions> {
  * @generated MessageType for protobuf message google.protobuf.ExtensionRangeOptions
  */
 export const ExtensionRangeOptions = new ExtensionRangeOptions$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ExtensionRangeOptions_Declaration$Type extends MessageType<ExtensionRangeOptions_Declaration> {
+    constructor() {
+        super("google.protobuf.ExtensionRangeOptions.Declaration", [
+            { no: 1, name: "number", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
+            { no: 2, name: "full_name", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "type", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 5, name: "reserved", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
+            { no: 6, name: "repeated", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ExtensionRangeOptions_Declaration>): ExtensionRangeOptions_Declaration {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<ExtensionRangeOptions_Declaration>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ExtensionRangeOptions_Declaration): ExtensionRangeOptions_Declaration {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* optional int32 number */ 1:
+                    message.number = reader.int32();
+                    break;
+                case /* optional string full_name */ 2:
+                    message.fullName = reader.string();
+                    break;
+                case /* optional string type */ 3:
+                    message.type = reader.string();
+                    break;
+                case /* optional bool reserved */ 5:
+                    message.reserved = reader.bool();
+                    break;
+                case /* optional bool repeated */ 6:
+                    message.repeated = reader.bool();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ExtensionRangeOptions_Declaration, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional int32 number = 1; */
+        if (message.number !== undefined)
+            writer.tag(1, WireType.Varint).int32(message.number);
+        /* optional string full_name = 2; */
+        if (message.fullName !== undefined)
+            writer.tag(2, WireType.LengthDelimited).string(message.fullName);
+        /* optional string type = 3; */
+        if (message.type !== undefined)
+            writer.tag(3, WireType.LengthDelimited).string(message.type);
+        /* optional bool reserved = 5; */
+        if (message.reserved !== undefined)
+            writer.tag(5, WireType.Varint).bool(message.reserved);
+        /* optional bool repeated = 6; */
+        if (message.repeated !== undefined)
+            writer.tag(6, WireType.Varint).bool(message.repeated);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message google.protobuf.ExtensionRangeOptions.Declaration
+ */
+export const ExtensionRangeOptions_Declaration = new ExtensionRangeOptions_Declaration$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class FieldDescriptorProto$Type extends MessageType<FieldDescriptorProto> {
     constructor() {
@@ -2107,7 +2991,8 @@ class EnumDescriptorProto$Type extends MessageType<EnumDescriptorProto> {
             { no: 2, name: "value", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => EnumValueDescriptorProto },
             { no: 3, name: "options", kind: "message", T: () => EnumOptions },
             { no: 4, name: "reserved_range", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => EnumDescriptorProto_EnumReservedRange },
-            { no: 5, name: "reserved_name", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
+            { no: 5, name: "reserved_name", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
+            { no: 6, name: "visibility", kind: "enum", opt: true, T: () => ["google.protobuf.SymbolVisibility", SymbolVisibility] }
         ]);
     }
     create(value?: PartialMessage<EnumDescriptorProto>): EnumDescriptorProto {
@@ -2139,6 +3024,9 @@ class EnumDescriptorProto$Type extends MessageType<EnumDescriptorProto> {
                 case /* repeated string reserved_name */ 5:
                     message.reservedName.push(reader.string());
                     break;
+                case /* optional google.protobuf.SymbolVisibility visibility */ 6:
+                    message.visibility = reader.int32();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -2166,6 +3054,9 @@ class EnumDescriptorProto$Type extends MessageType<EnumDescriptorProto> {
         /* repeated string reserved_name = 5; */
         for (let i = 0; i < message.reservedName.length; i++)
             writer.tag(5, WireType.LengthDelimited).string(message.reservedName[i]);
+        /* optional google.protobuf.SymbolVisibility visibility = 6; */
+        if (message.visibility !== undefined)
+            writer.tag(6, WireType.Varint).int32(message.visibility);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -2445,7 +3336,6 @@ class FileOptions$Type extends MessageType<FileOptions> {
             { no: 16, name: "cc_generic_services", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 17, name: "java_generic_services", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 18, name: "py_generic_services", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
-            { no: 42, name: "php_generic_services", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 23, name: "deprecated", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 31, name: "cc_enable_arenas", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 36, name: "objc_class_prefix", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
@@ -2455,6 +3345,7 @@ class FileOptions$Type extends MessageType<FileOptions> {
             { no: 41, name: "php_namespace", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
             { no: 44, name: "php_metadata_namespace", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
             { no: 45, name: "ruby_package", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 50, name: "features", kind: "message", T: () => FeatureSet },
             { no: 999, name: "uninterpreted_option", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => UninterpretedOption }
         ]);
     }
@@ -2500,9 +3391,6 @@ class FileOptions$Type extends MessageType<FileOptions> {
                 case /* optional bool py_generic_services */ 18:
                     message.pyGenericServices = reader.bool();
                     break;
-                case /* optional bool php_generic_services */ 42:
-                    message.phpGenericServices = reader.bool();
-                    break;
                 case /* optional bool deprecated */ 23:
                     message.deprecated = reader.bool();
                     break;
@@ -2529,6 +3417,9 @@ class FileOptions$Type extends MessageType<FileOptions> {
                     break;
                 case /* optional string ruby_package */ 45:
                     message.rubyPackage = reader.string();
+                    break;
+                case /* optional google.protobuf.FeatureSet features */ 50:
+                    message.features = FeatureSet.internalBinaryRead(reader, reader.uint32(), options, message.features);
                     break;
                 case /* repeated google.protobuf.UninterpretedOption uninterpreted_option */ 999:
                     message.uninterpretedOption.push(UninterpretedOption.internalBinaryRead(reader, reader.uint32(), options));
@@ -2575,9 +3466,6 @@ class FileOptions$Type extends MessageType<FileOptions> {
         /* optional bool py_generic_services = 18; */
         if (message.pyGenericServices !== undefined)
             writer.tag(18, WireType.Varint).bool(message.pyGenericServices);
-        /* optional bool php_generic_services = 42; */
-        if (message.phpGenericServices !== undefined)
-            writer.tag(42, WireType.Varint).bool(message.phpGenericServices);
         /* optional bool deprecated = 23; */
         if (message.deprecated !== undefined)
             writer.tag(23, WireType.Varint).bool(message.deprecated);
@@ -2605,6 +3493,9 @@ class FileOptions$Type extends MessageType<FileOptions> {
         /* optional string ruby_package = 45; */
         if (message.rubyPackage !== undefined)
             writer.tag(45, WireType.LengthDelimited).string(message.rubyPackage);
+        /* optional google.protobuf.FeatureSet features = 50; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(50, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
         for (let i = 0; i < message.uninterpretedOption.length; i++)
             UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
@@ -2626,6 +3517,8 @@ class MessageOptions$Type extends MessageType<MessageOptions> {
             { no: 2, name: "no_standard_descriptor_accessor", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 3, name: "deprecated", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 7, name: "map_entry", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
+            { no: 11, name: "deprecated_legacy_json_field_conflicts", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
+            { no: 12, name: "features", kind: "message", T: () => FeatureSet },
             { no: 999, name: "uninterpreted_option", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => UninterpretedOption }
         ]);
     }
@@ -2652,6 +3545,12 @@ class MessageOptions$Type extends MessageType<MessageOptions> {
                     break;
                 case /* optional bool map_entry */ 7:
                     message.mapEntry = reader.bool();
+                    break;
+                case /* optional bool deprecated_legacy_json_field_conflicts = 11 [deprecated = true];*/ 11:
+                    message.deprecatedLegacyJsonFieldConflicts = reader.bool();
+                    break;
+                case /* optional google.protobuf.FeatureSet features */ 12:
+                    message.features = FeatureSet.internalBinaryRead(reader, reader.uint32(), options, message.features);
                     break;
                 case /* repeated google.protobuf.UninterpretedOption uninterpreted_option */ 999:
                     message.uninterpretedOption.push(UninterpretedOption.internalBinaryRead(reader, reader.uint32(), options));
@@ -2680,6 +3579,12 @@ class MessageOptions$Type extends MessageType<MessageOptions> {
         /* optional bool map_entry = 7; */
         if (message.mapEntry !== undefined)
             writer.tag(7, WireType.Varint).bool(message.mapEntry);
+        /* optional bool deprecated_legacy_json_field_conflicts = 11 [deprecated = true]; */
+        if (message.deprecatedLegacyJsonFieldConflicts !== undefined)
+            writer.tag(11, WireType.Varint).bool(message.deprecatedLegacyJsonFieldConflicts);
+        /* optional google.protobuf.FeatureSet features = 12; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(12, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
         for (let i = 0; i < message.uninterpretedOption.length; i++)
             UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
@@ -2704,11 +3609,19 @@ class FieldOptions$Type extends MessageType<FieldOptions> {
             { no: 15, name: "unverified_lazy", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 3, name: "deprecated", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 10, name: "weak", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
+            { no: 16, name: "debug_redact", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
+            { no: 17, name: "retention", kind: "enum", opt: true, T: () => ["google.protobuf.FieldOptions.OptionRetention", FieldOptions_OptionRetention] },
+            { no: 19, name: "targets", kind: "enum", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ["google.protobuf.FieldOptions.OptionTargetType", FieldOptions_OptionTargetType] },
+            { no: 20, name: "edition_defaults", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => FieldOptions_EditionDefault },
+            { no: 21, name: "features", kind: "message", T: () => FeatureSet },
+            { no: 22, name: "feature_support", kind: "message", T: () => FieldOptions_FeatureSupport },
             { no: 999, name: "uninterpreted_option", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => UninterpretedOption }
         ]);
     }
     create(value?: PartialMessage<FieldOptions>): FieldOptions {
         const message = globalThis.Object.create((this.messagePrototype!));
+        message.targets = [];
+        message.editionDefaults = [];
         message.uninterpretedOption = [];
         if (value !== undefined)
             reflectionMergePartial<FieldOptions>(this, message, value);
@@ -2739,6 +3652,28 @@ class FieldOptions$Type extends MessageType<FieldOptions> {
                     break;
                 case /* optional bool weak */ 10:
                     message.weak = reader.bool();
+                    break;
+                case /* optional bool debug_redact */ 16:
+                    message.debugRedact = reader.bool();
+                    break;
+                case /* optional google.protobuf.FieldOptions.OptionRetention retention */ 17:
+                    message.retention = reader.int32();
+                    break;
+                case /* repeated google.protobuf.FieldOptions.OptionTargetType targets */ 19:
+                    if (wireType === WireType.LengthDelimited)
+                        for (let e = reader.int32() + reader.pos; reader.pos < e;)
+                            message.targets.push(reader.int32());
+                    else
+                        message.targets.push(reader.int32());
+                    break;
+                case /* repeated google.protobuf.FieldOptions.EditionDefault edition_defaults */ 20:
+                    message.editionDefaults.push(FieldOptions_EditionDefault.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* optional google.protobuf.FeatureSet features */ 21:
+                    message.features = FeatureSet.internalBinaryRead(reader, reader.uint32(), options, message.features);
+                    break;
+                case /* optional google.protobuf.FieldOptions.FeatureSupport feature_support */ 22:
+                    message.featureSupport = FieldOptions_FeatureSupport.internalBinaryRead(reader, reader.uint32(), options, message.featureSupport);
                     break;
                 case /* repeated google.protobuf.UninterpretedOption uninterpreted_option */ 999:
                     message.uninterpretedOption.push(UninterpretedOption.internalBinaryRead(reader, reader.uint32(), options));
@@ -2776,6 +3711,24 @@ class FieldOptions$Type extends MessageType<FieldOptions> {
         /* optional bool weak = 10; */
         if (message.weak !== undefined)
             writer.tag(10, WireType.Varint).bool(message.weak);
+        /* optional bool debug_redact = 16; */
+        if (message.debugRedact !== undefined)
+            writer.tag(16, WireType.Varint).bool(message.debugRedact);
+        /* optional google.protobuf.FieldOptions.OptionRetention retention = 17; */
+        if (message.retention !== undefined)
+            writer.tag(17, WireType.Varint).int32(message.retention);
+        /* repeated google.protobuf.FieldOptions.OptionTargetType targets = 19; */
+        for (let i = 0; i < message.targets.length; i++)
+            writer.tag(19, WireType.Varint).int32(message.targets[i]);
+        /* repeated google.protobuf.FieldOptions.EditionDefault edition_defaults = 20; */
+        for (let i = 0; i < message.editionDefaults.length; i++)
+            FieldOptions_EditionDefault.internalBinaryWrite(message.editionDefaults[i], writer.tag(20, WireType.LengthDelimited).fork(), options).join();
+        /* optional google.protobuf.FeatureSet features = 21; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(21, WireType.LengthDelimited).fork(), options).join();
+        /* optional google.protobuf.FieldOptions.FeatureSupport feature_support = 22; */
+        if (message.featureSupport)
+            FieldOptions_FeatureSupport.internalBinaryWrite(message.featureSupport, writer.tag(22, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
         for (let i = 0; i < message.uninterpretedOption.length; i++)
             UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
@@ -2790,9 +3743,130 @@ class FieldOptions$Type extends MessageType<FieldOptions> {
  */
 export const FieldOptions = new FieldOptions$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class FieldOptions_EditionDefault$Type extends MessageType<FieldOptions_EditionDefault> {
+    constructor() {
+        super("google.protobuf.FieldOptions.EditionDefault", [
+            { no: 3, name: "edition", kind: "enum", opt: true, T: () => ["google.protobuf.Edition", Edition] },
+            { no: 2, name: "value", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<FieldOptions_EditionDefault>): FieldOptions_EditionDefault {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<FieldOptions_EditionDefault>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: FieldOptions_EditionDefault): FieldOptions_EditionDefault {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* optional google.protobuf.Edition edition */ 3:
+                    message.edition = reader.int32();
+                    break;
+                case /* optional string value */ 2:
+                    message.value = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: FieldOptions_EditionDefault, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional google.protobuf.Edition edition = 3; */
+        if (message.edition !== undefined)
+            writer.tag(3, WireType.Varint).int32(message.edition);
+        /* optional string value = 2; */
+        if (message.value !== undefined)
+            writer.tag(2, WireType.LengthDelimited).string(message.value);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message google.protobuf.FieldOptions.EditionDefault
+ */
+export const FieldOptions_EditionDefault = new FieldOptions_EditionDefault$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class FieldOptions_FeatureSupport$Type extends MessageType<FieldOptions_FeatureSupport> {
+    constructor() {
+        super("google.protobuf.FieldOptions.FeatureSupport", [
+            { no: 1, name: "edition_introduced", kind: "enum", opt: true, T: () => ["google.protobuf.Edition", Edition] },
+            { no: 2, name: "edition_deprecated", kind: "enum", opt: true, T: () => ["google.protobuf.Edition", Edition] },
+            { no: 3, name: "deprecation_warning", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 4, name: "edition_removed", kind: "enum", opt: true, T: () => ["google.protobuf.Edition", Edition] }
+        ]);
+    }
+    create(value?: PartialMessage<FieldOptions_FeatureSupport>): FieldOptions_FeatureSupport {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<FieldOptions_FeatureSupport>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: FieldOptions_FeatureSupport): FieldOptions_FeatureSupport {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* optional google.protobuf.Edition edition_introduced */ 1:
+                    message.editionIntroduced = reader.int32();
+                    break;
+                case /* optional google.protobuf.Edition edition_deprecated */ 2:
+                    message.editionDeprecated = reader.int32();
+                    break;
+                case /* optional string deprecation_warning */ 3:
+                    message.deprecationWarning = reader.string();
+                    break;
+                case /* optional google.protobuf.Edition edition_removed */ 4:
+                    message.editionRemoved = reader.int32();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: FieldOptions_FeatureSupport, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional google.protobuf.Edition edition_introduced = 1; */
+        if (message.editionIntroduced !== undefined)
+            writer.tag(1, WireType.Varint).int32(message.editionIntroduced);
+        /* optional google.protobuf.Edition edition_deprecated = 2; */
+        if (message.editionDeprecated !== undefined)
+            writer.tag(2, WireType.Varint).int32(message.editionDeprecated);
+        /* optional string deprecation_warning = 3; */
+        if (message.deprecationWarning !== undefined)
+            writer.tag(3, WireType.LengthDelimited).string(message.deprecationWarning);
+        /* optional google.protobuf.Edition edition_removed = 4; */
+        if (message.editionRemoved !== undefined)
+            writer.tag(4, WireType.Varint).int32(message.editionRemoved);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message google.protobuf.FieldOptions.FeatureSupport
+ */
+export const FieldOptions_FeatureSupport = new FieldOptions_FeatureSupport$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class OneofOptions$Type extends MessageType<OneofOptions> {
     constructor() {
         super("google.protobuf.OneofOptions", [
+            { no: 1, name: "features", kind: "message", T: () => FeatureSet },
             { no: 999, name: "uninterpreted_option", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => UninterpretedOption }
         ]);
     }
@@ -2808,6 +3882,9 @@ class OneofOptions$Type extends MessageType<OneofOptions> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
+                case /* optional google.protobuf.FeatureSet features */ 1:
+                    message.features = FeatureSet.internalBinaryRead(reader, reader.uint32(), options, message.features);
+                    break;
                 case /* repeated google.protobuf.UninterpretedOption uninterpreted_option */ 999:
                     message.uninterpretedOption.push(UninterpretedOption.internalBinaryRead(reader, reader.uint32(), options));
                     break;
@@ -2823,6 +3900,9 @@ class OneofOptions$Type extends MessageType<OneofOptions> {
         return message;
     }
     internalBinaryWrite(message: OneofOptions, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional google.protobuf.FeatureSet features = 1; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
         for (let i = 0; i < message.uninterpretedOption.length; i++)
             UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
@@ -2842,6 +3922,8 @@ class EnumOptions$Type extends MessageType<EnumOptions> {
         super("google.protobuf.EnumOptions", [
             { no: 2, name: "allow_alias", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 3, name: "deprecated", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
+            { no: 6, name: "deprecated_legacy_json_field_conflicts", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
+            { no: 7, name: "features", kind: "message", T: () => FeatureSet },
             { no: 999, name: "uninterpreted_option", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => UninterpretedOption }
         ]);
     }
@@ -2862,6 +3944,12 @@ class EnumOptions$Type extends MessageType<EnumOptions> {
                     break;
                 case /* optional bool deprecated */ 3:
                     message.deprecated = reader.bool();
+                    break;
+                case /* optional bool deprecated_legacy_json_field_conflicts = 6 [deprecated = true];*/ 6:
+                    message.deprecatedLegacyJsonFieldConflicts = reader.bool();
+                    break;
+                case /* optional google.protobuf.FeatureSet features */ 7:
+                    message.features = FeatureSet.internalBinaryRead(reader, reader.uint32(), options, message.features);
                     break;
                 case /* repeated google.protobuf.UninterpretedOption uninterpreted_option */ 999:
                     message.uninterpretedOption.push(UninterpretedOption.internalBinaryRead(reader, reader.uint32(), options));
@@ -2884,6 +3972,12 @@ class EnumOptions$Type extends MessageType<EnumOptions> {
         /* optional bool deprecated = 3; */
         if (message.deprecated !== undefined)
             writer.tag(3, WireType.Varint).bool(message.deprecated);
+        /* optional bool deprecated_legacy_json_field_conflicts = 6 [deprecated = true]; */
+        if (message.deprecatedLegacyJsonFieldConflicts !== undefined)
+            writer.tag(6, WireType.Varint).bool(message.deprecatedLegacyJsonFieldConflicts);
+        /* optional google.protobuf.FeatureSet features = 7; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
         for (let i = 0; i < message.uninterpretedOption.length; i++)
             UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
@@ -2902,6 +3996,9 @@ class EnumValueOptions$Type extends MessageType<EnumValueOptions> {
     constructor() {
         super("google.protobuf.EnumValueOptions", [
             { no: 1, name: "deprecated", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
+            { no: 2, name: "features", kind: "message", T: () => FeatureSet },
+            { no: 3, name: "debug_redact", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
+            { no: 4, name: "feature_support", kind: "message", T: () => FieldOptions_FeatureSupport },
             { no: 999, name: "uninterpreted_option", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => UninterpretedOption }
         ]);
     }
@@ -2919,6 +4016,15 @@ class EnumValueOptions$Type extends MessageType<EnumValueOptions> {
             switch (fieldNo) {
                 case /* optional bool deprecated */ 1:
                     message.deprecated = reader.bool();
+                    break;
+                case /* optional google.protobuf.FeatureSet features */ 2:
+                    message.features = FeatureSet.internalBinaryRead(reader, reader.uint32(), options, message.features);
+                    break;
+                case /* optional bool debug_redact */ 3:
+                    message.debugRedact = reader.bool();
+                    break;
+                case /* optional google.protobuf.FieldOptions.FeatureSupport feature_support */ 4:
+                    message.featureSupport = FieldOptions_FeatureSupport.internalBinaryRead(reader, reader.uint32(), options, message.featureSupport);
                     break;
                 case /* repeated google.protobuf.UninterpretedOption uninterpreted_option */ 999:
                     message.uninterpretedOption.push(UninterpretedOption.internalBinaryRead(reader, reader.uint32(), options));
@@ -2938,6 +4044,15 @@ class EnumValueOptions$Type extends MessageType<EnumValueOptions> {
         /* optional bool deprecated = 1; */
         if (message.deprecated !== undefined)
             writer.tag(1, WireType.Varint).bool(message.deprecated);
+        /* optional google.protobuf.FeatureSet features = 2; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* optional bool debug_redact = 3; */
+        if (message.debugRedact !== undefined)
+            writer.tag(3, WireType.Varint).bool(message.debugRedact);
+        /* optional google.protobuf.FieldOptions.FeatureSupport feature_support = 4; */
+        if (message.featureSupport)
+            FieldOptions_FeatureSupport.internalBinaryWrite(message.featureSupport, writer.tag(4, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
         for (let i = 0; i < message.uninterpretedOption.length; i++)
             UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
@@ -2955,6 +4070,7 @@ export const EnumValueOptions = new EnumValueOptions$Type();
 class ServiceOptions$Type extends MessageType<ServiceOptions> {
     constructor() {
         super("google.protobuf.ServiceOptions", [
+            { no: 34, name: "features", kind: "message", T: () => FeatureSet },
             { no: 33, name: "deprecated", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 999, name: "uninterpreted_option", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => UninterpretedOption }
         ]);
@@ -2971,6 +4087,9 @@ class ServiceOptions$Type extends MessageType<ServiceOptions> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
+                case /* optional google.protobuf.FeatureSet features */ 34:
+                    message.features = FeatureSet.internalBinaryRead(reader, reader.uint32(), options, message.features);
+                    break;
                 case /* optional bool deprecated */ 33:
                     message.deprecated = reader.bool();
                     break;
@@ -2989,6 +4108,9 @@ class ServiceOptions$Type extends MessageType<ServiceOptions> {
         return message;
     }
     internalBinaryWrite(message: ServiceOptions, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional google.protobuf.FeatureSet features = 34; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(34, WireType.LengthDelimited).fork(), options).join();
         /* optional bool deprecated = 33; */
         if (message.deprecated !== undefined)
             writer.tag(33, WireType.Varint).bool(message.deprecated);
@@ -3011,6 +4133,7 @@ class MethodOptions$Type extends MessageType<MethodOptions> {
         super("google.protobuf.MethodOptions", [
             { no: 33, name: "deprecated", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 34, name: "idempotency_level", kind: "enum", opt: true, T: () => ["google.protobuf.MethodOptions.IdempotencyLevel", MethodOptions_IdempotencyLevel] },
+            { no: 35, name: "features", kind: "message", T: () => FeatureSet },
             { no: 999, name: "uninterpreted_option", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => UninterpretedOption }
         ]);
     }
@@ -3031,6 +4154,9 @@ class MethodOptions$Type extends MessageType<MethodOptions> {
                     break;
                 case /* optional google.protobuf.MethodOptions.IdempotencyLevel idempotency_level */ 34:
                     message.idempotencyLevel = reader.int32();
+                    break;
+                case /* optional google.protobuf.FeatureSet features */ 35:
+                    message.features = FeatureSet.internalBinaryRead(reader, reader.uint32(), options, message.features);
                     break;
                 case /* repeated google.protobuf.UninterpretedOption uninterpreted_option */ 999:
                     message.uninterpretedOption.push(UninterpretedOption.internalBinaryRead(reader, reader.uint32(), options));
@@ -3053,6 +4179,9 @@ class MethodOptions$Type extends MessageType<MethodOptions> {
         /* optional google.protobuf.MethodOptions.IdempotencyLevel idempotency_level = 34; */
         if (message.idempotencyLevel !== undefined)
             writer.tag(34, WireType.Varint).int32(message.idempotencyLevel);
+        /* optional google.protobuf.FeatureSet features = 35; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(35, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
         for (let i = 0; i < message.uninterpretedOption.length; i++)
             UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
@@ -3210,6 +4339,247 @@ class UninterpretedOption_NamePart$Type extends MessageType<UninterpretedOption_
  * @generated MessageType for protobuf message google.protobuf.UninterpretedOption.NamePart
  */
 export const UninterpretedOption_NamePart = new UninterpretedOption_NamePart$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class FeatureSet$Type extends MessageType<FeatureSet> {
+    constructor() {
+        super("google.protobuf.FeatureSet", [
+            { no: 1, name: "field_presence", kind: "enum", opt: true, T: () => ["google.protobuf.FeatureSet.FieldPresence", FeatureSet_FieldPresence] },
+            { no: 2, name: "enum_type", kind: "enum", opt: true, T: () => ["google.protobuf.FeatureSet.EnumType", FeatureSet_EnumType] },
+            { no: 3, name: "repeated_field_encoding", kind: "enum", opt: true, T: () => ["google.protobuf.FeatureSet.RepeatedFieldEncoding", FeatureSet_RepeatedFieldEncoding] },
+            { no: 4, name: "utf8_validation", kind: "enum", opt: true, T: () => ["google.protobuf.FeatureSet.Utf8Validation", FeatureSet_Utf8Validation] },
+            { no: 5, name: "message_encoding", kind: "enum", opt: true, T: () => ["google.protobuf.FeatureSet.MessageEncoding", FeatureSet_MessageEncoding] },
+            { no: 6, name: "json_format", kind: "enum", opt: true, T: () => ["google.protobuf.FeatureSet.JsonFormat", FeatureSet_JsonFormat] },
+            { no: 7, name: "enforce_naming_style", kind: "enum", opt: true, T: () => ["google.protobuf.FeatureSet.EnforceNamingStyle", FeatureSet_EnforceNamingStyle] },
+            { no: 8, name: "default_symbol_visibility", kind: "enum", opt: true, T: () => ["google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility", FeatureSet_VisibilityFeature_DefaultSymbolVisibility] }
+        ]);
+    }
+    create(value?: PartialMessage<FeatureSet>): FeatureSet {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<FeatureSet>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: FeatureSet): FeatureSet {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* optional google.protobuf.FeatureSet.FieldPresence field_presence */ 1:
+                    message.fieldPresence = reader.int32();
+                    break;
+                case /* optional google.protobuf.FeatureSet.EnumType enum_type */ 2:
+                    message.enumType = reader.int32();
+                    break;
+                case /* optional google.protobuf.FeatureSet.RepeatedFieldEncoding repeated_field_encoding */ 3:
+                    message.repeatedFieldEncoding = reader.int32();
+                    break;
+                case /* optional google.protobuf.FeatureSet.Utf8Validation utf8_validation */ 4:
+                    message.utf8Validation = reader.int32();
+                    break;
+                case /* optional google.protobuf.FeatureSet.MessageEncoding message_encoding */ 5:
+                    message.messageEncoding = reader.int32();
+                    break;
+                case /* optional google.protobuf.FeatureSet.JsonFormat json_format */ 6:
+                    message.jsonFormat = reader.int32();
+                    break;
+                case /* optional google.protobuf.FeatureSet.EnforceNamingStyle enforce_naming_style */ 7:
+                    message.enforceNamingStyle = reader.int32();
+                    break;
+                case /* optional google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility default_symbol_visibility */ 8:
+                    message.defaultSymbolVisibility = reader.int32();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: FeatureSet, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional google.protobuf.FeatureSet.FieldPresence field_presence = 1; */
+        if (message.fieldPresence !== undefined)
+            writer.tag(1, WireType.Varint).int32(message.fieldPresence);
+        /* optional google.protobuf.FeatureSet.EnumType enum_type = 2; */
+        if (message.enumType !== undefined)
+            writer.tag(2, WireType.Varint).int32(message.enumType);
+        /* optional google.protobuf.FeatureSet.RepeatedFieldEncoding repeated_field_encoding = 3; */
+        if (message.repeatedFieldEncoding !== undefined)
+            writer.tag(3, WireType.Varint).int32(message.repeatedFieldEncoding);
+        /* optional google.protobuf.FeatureSet.Utf8Validation utf8_validation = 4; */
+        if (message.utf8Validation !== undefined)
+            writer.tag(4, WireType.Varint).int32(message.utf8Validation);
+        /* optional google.protobuf.FeatureSet.MessageEncoding message_encoding = 5; */
+        if (message.messageEncoding !== undefined)
+            writer.tag(5, WireType.Varint).int32(message.messageEncoding);
+        /* optional google.protobuf.FeatureSet.JsonFormat json_format = 6; */
+        if (message.jsonFormat !== undefined)
+            writer.tag(6, WireType.Varint).int32(message.jsonFormat);
+        /* optional google.protobuf.FeatureSet.EnforceNamingStyle enforce_naming_style = 7; */
+        if (message.enforceNamingStyle !== undefined)
+            writer.tag(7, WireType.Varint).int32(message.enforceNamingStyle);
+        /* optional google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility default_symbol_visibility = 8; */
+        if (message.defaultSymbolVisibility !== undefined)
+            writer.tag(8, WireType.Varint).int32(message.defaultSymbolVisibility);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message google.protobuf.FeatureSet
+ */
+export const FeatureSet = new FeatureSet$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class FeatureSet_VisibilityFeature$Type extends MessageType<FeatureSet_VisibilityFeature> {
+    constructor() {
+        super("google.protobuf.FeatureSet.VisibilityFeature", []);
+    }
+    create(value?: PartialMessage<FeatureSet_VisibilityFeature>): FeatureSet_VisibilityFeature {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<FeatureSet_VisibilityFeature>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: FeatureSet_VisibilityFeature): FeatureSet_VisibilityFeature {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: FeatureSet_VisibilityFeature, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message google.protobuf.FeatureSet.VisibilityFeature
+ */
+export const FeatureSet_VisibilityFeature = new FeatureSet_VisibilityFeature$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class FeatureSetDefaults$Type extends MessageType<FeatureSetDefaults> {
+    constructor() {
+        super("google.protobuf.FeatureSetDefaults", [
+            { no: 1, name: "defaults", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => FeatureSetDefaults_FeatureSetEditionDefault },
+            { no: 4, name: "minimum_edition", kind: "enum", opt: true, T: () => ["google.protobuf.Edition", Edition] },
+            { no: 5, name: "maximum_edition", kind: "enum", opt: true, T: () => ["google.protobuf.Edition", Edition] }
+        ]);
+    }
+    create(value?: PartialMessage<FeatureSetDefaults>): FeatureSetDefaults {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.defaults = [];
+        if (value !== undefined)
+            reflectionMergePartial<FeatureSetDefaults>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: FeatureSetDefaults): FeatureSetDefaults {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* repeated google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault defaults */ 1:
+                    message.defaults.push(FeatureSetDefaults_FeatureSetEditionDefault.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* optional google.protobuf.Edition minimum_edition */ 4:
+                    message.minimumEdition = reader.int32();
+                    break;
+                case /* optional google.protobuf.Edition maximum_edition */ 5:
+                    message.maximumEdition = reader.int32();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: FeatureSetDefaults, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault defaults = 1; */
+        for (let i = 0; i < message.defaults.length; i++)
+            FeatureSetDefaults_FeatureSetEditionDefault.internalBinaryWrite(message.defaults[i], writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        /* optional google.protobuf.Edition minimum_edition = 4; */
+        if (message.minimumEdition !== undefined)
+            writer.tag(4, WireType.Varint).int32(message.minimumEdition);
+        /* optional google.protobuf.Edition maximum_edition = 5; */
+        if (message.maximumEdition !== undefined)
+            writer.tag(5, WireType.Varint).int32(message.maximumEdition);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message google.protobuf.FeatureSetDefaults
+ */
+export const FeatureSetDefaults = new FeatureSetDefaults$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class FeatureSetDefaults_FeatureSetEditionDefault$Type extends MessageType<FeatureSetDefaults_FeatureSetEditionDefault> {
+    constructor() {
+        super("google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault", [
+            { no: 3, name: "edition", kind: "enum", opt: true, T: () => ["google.protobuf.Edition", Edition] },
+            { no: 4, name: "overridable_features", kind: "message", T: () => FeatureSet },
+            { no: 5, name: "fixed_features", kind: "message", T: () => FeatureSet }
+        ]);
+    }
+    create(value?: PartialMessage<FeatureSetDefaults_FeatureSetEditionDefault>): FeatureSetDefaults_FeatureSetEditionDefault {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<FeatureSetDefaults_FeatureSetEditionDefault>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: FeatureSetDefaults_FeatureSetEditionDefault): FeatureSetDefaults_FeatureSetEditionDefault {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* optional google.protobuf.Edition edition */ 3:
+                    message.edition = reader.int32();
+                    break;
+                case /* optional google.protobuf.FeatureSet overridable_features */ 4:
+                    message.overridableFeatures = FeatureSet.internalBinaryRead(reader, reader.uint32(), options, message.overridableFeatures);
+                    break;
+                case /* optional google.protobuf.FeatureSet fixed_features */ 5:
+                    message.fixedFeatures = FeatureSet.internalBinaryRead(reader, reader.uint32(), options, message.fixedFeatures);
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: FeatureSetDefaults_FeatureSetEditionDefault, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional google.protobuf.Edition edition = 3; */
+        if (message.edition !== undefined)
+            writer.tag(3, WireType.Varint).int32(message.edition);
+        /* optional google.protobuf.FeatureSet overridable_features = 4; */
+        if (message.overridableFeatures)
+            FeatureSet.internalBinaryWrite(message.overridableFeatures, writer.tag(4, WireType.LengthDelimited).fork(), options).join();
+        /* optional google.protobuf.FeatureSet fixed_features = 5; */
+        if (message.fixedFeatures)
+            FeatureSet.internalBinaryWrite(message.fixedFeatures, writer.tag(5, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault
+ */
+export const FeatureSetDefaults_FeatureSetEditionDefault = new FeatureSetDefaults_FeatureSetEditionDefault$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class SourceCodeInfo$Type extends MessageType<SourceCodeInfo> {
     constructor() {
@@ -3404,7 +4774,8 @@ class GeneratedCodeInfo_Annotation$Type extends MessageType<GeneratedCodeInfo_An
             { no: 1, name: "path", kind: "scalar", repeat: 1 /*RepeatType.PACKED*/, T: 5 /*ScalarType.INT32*/ },
             { no: 2, name: "source_file", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
             { no: 3, name: "begin", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
-            { no: 4, name: "end", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ }
+            { no: 4, name: "end", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
+            { no: 5, name: "semantic", kind: "enum", opt: true, T: () => ["google.protobuf.GeneratedCodeInfo.Annotation.Semantic", GeneratedCodeInfo_Annotation_Semantic] }
         ]);
     }
     create(value?: PartialMessage<GeneratedCodeInfo_Annotation>): GeneratedCodeInfo_Annotation {
@@ -3435,6 +4806,9 @@ class GeneratedCodeInfo_Annotation$Type extends MessageType<GeneratedCodeInfo_An
                 case /* optional int32 end */ 4:
                     message.end = reader.int32();
                     break;
+                case /* optional google.protobuf.GeneratedCodeInfo.Annotation.Semantic semantic */ 5:
+                    message.semantic = reader.int32();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -3463,6 +4837,9 @@ class GeneratedCodeInfo_Annotation$Type extends MessageType<GeneratedCodeInfo_An
         /* optional int32 end = 4; */
         if (message.end !== undefined)
             writer.tag(4, WireType.Varint).int32(message.end);
+        /* optional google.protobuf.GeneratedCodeInfo.Annotation.Semantic semantic = 5; */
+        if (message.semantic !== undefined)
+            writer.tag(5, WireType.Varint).int32(message.semantic);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/src/pomerium-console/google/protobuf/duration.ts
+++ b/src/pomerium-console/google/protobuf/duration.ts
@@ -107,7 +107,6 @@ import { MessageType } from "@protobuf-ts/runtime";
  * microsecond should be expressed in JSON format as "3.000001s".
  *
  *
- *
  * @generated from protobuf message google.protobuf.Duration
  */
 export interface Duration {

--- a/src/pomerium-console/google/protobuf/struct.ts
+++ b/src/pomerium-console/google/protobuf/struct.ts
@@ -154,7 +154,7 @@ export interface ListValue {
  * `NullValue` is a singleton enumeration to represent the null value for the
  * `Value` type union.
  *
- *  The JSON representation for `NullValue` is JSON `null`.
+ * The JSON representation for `NullValue` is JSON `null`.
  *
  * @generated from protobuf enum google.protobuf.NullValue
  */

--- a/src/pomerium-console/google/protobuf/timestamp.ts
+++ b/src/pomerium-console/google/protobuf/timestamp.ts
@@ -97,7 +97,6 @@ import { MessageType } from "@protobuf-ts/runtime";
  *     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
  *         .setNanos((int) ((millis % 1000) * 1000000)).build();
  *
- *
  * Example 5: Compute Timestamp from Java `Instant.now()`.
  *
  *     Instant now = Instant.now();
@@ -105,7 +104,6 @@ import { MessageType } from "@protobuf-ts/runtime";
  *     Timestamp timestamp =
  *         Timestamp.newBuilder().setSeconds(now.getEpochSecond())
  *             .setNanos(now.getNano()).build();
- *
  *
  * Example 6: Compute Timestamp from current time in Python.
  *
@@ -136,9 +134,8 @@ import { MessageType } from "@protobuf-ts/runtime";
  * [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
  * the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
  * the Joda Time's [`ISODateTimeFormat.dateTime()`](
- * http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%2D%2D
+ * http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
  * ) to obtain a formatter capable of generating timestamps in this format.
- *
  *
  *
  * @generated from protobuf message google.protobuf.Timestamp


### PR DESCRIPTION
It looks like the generated code in the google/protobuf directory has gotten out of sync with the underlying proto definitions.

(Unless these are somehow coming from a dependency that hasn't been pinned?)