### PR TITLE
chore: drop submodules for publish and release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          submodules: recursive
           persist-credentials: false
           ref: ${{ github.event.inputs.tag }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          submodules: recursive
           persist-credentials: false
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020


### PR DESCRIPTION
## Summary

Submodules only provide .proto sources for codegen; the generated TypeScript is already committed under src/. Fetching the private enterprise-client submodule failed during publish, so remove it.

## AI Disclosure

Sorted it out with Devin (Opus 4.8) after analyzing failing publish job.
