### PR TITLE
chore: bump package.json to version 0.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pomerium/enterprise-client-node",
-  "version": "0.1.0",
+  "version": "0.32.0",
   "author": "Caleb Doxsey <cdoxsey@pomerium.com>",
   "description": "NodeJS client for the Pomerium Enterprise Console",
   "scripts": {


### PR DESCRIPTION
Fixes issue with initial publish to npm with an official version.

```
Run VERSION=$(node -p "require('./package.json').version")
Error: package.json version (0.1.0) does not match tag (0.32.0)
Error: Process completed with exit code 1.
```
https://github.com/pomerium/enterprise-client-node/actions/runs/28038659788/job/82998821438

