### PR TITLE
fix: update release-please-action to v5.0.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
-      - uses: googleapis/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Summary

The previously pinned SHA e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee does
not exist in googleapis/release-please-action, causing the release job
to fail immediately at setup.

Generated with [Devin](https://devin.ai)

Co-Authored-By: Devin <158243242+devin-ai-integration[bot]@users.noreply.github.com>

This should trigger a 0.32.1 release @calebdoxsey 

## AI Disclosure

Discussed the best approach to get a first release for 0.32.x with Devin. Opted for making this PR a fix so we can trigger the release workflow.