### PR TITLE
chore: opt for GITHUB_TOKEN over PAT for Release Please

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

opt for GITHUB_TOKEN over PAT for Release Please

Better from a security standpoint and also, the PAT did not exist which is why the workflow failed.

## AI Disclosure

Just chatted to go with GH token.
