### PR TITLE
chore: include-component-in-tag set to false for clean tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "include-component-in-tag": false,
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
## Summary

Set `include-component-in-tag` to false so as to not pollute tags with the package name, e.g. tag as `v0.32.1` instead of `enterprise-client-node-v0.32.1`.